### PR TITLE
block messages repeat on 0 free

### DIFF
--- a/src/scenes/harks.ts
+++ b/src/scenes/harks.ts
@@ -56,12 +56,14 @@ harkScene.action(/info(?=_)/, async (ctx) => {
 });
 
 harkScene.action(/confirm|reset|back|increase(?=_)/, async (ctx) => {
+  let x = false;
   if (ctx.match.input.includes('increase_')) {
     try {
       const [, hark] = ctx.match.input.split('_');
       ctx.session.character.increaseHark(hark);
     } catch (e) {
       await ctx.answerCbQuery(e.message);
+      x = true;
     }
   }
   if (ctx.match.input === 'confirm') {
@@ -72,7 +74,7 @@ harkScene.action(/confirm|reset|back|increase(?=_)/, async (ctx) => {
     ctx.session.character.resetHarks();
     await ctx.answerCbQuery('Изменения успешно сброшены');
   }
-
+  if (x) return;
   await ctx.editMessageText(
     `Свободных очков ${ctx.session.character.free}`,
     Markup.inlineKeyboard([

--- a/src/scenes/harks.ts
+++ b/src/scenes/harks.ts
@@ -56,14 +56,13 @@ harkScene.action(/info(?=_)/, async (ctx) => {
 });
 
 harkScene.action(/confirm|reset|back|increase(?=_)/, async (ctx) => {
-  let x = false;
   if (ctx.match.input.includes('increase_')) {
     try {
       const [, hark] = ctx.match.input.split('_');
       ctx.session.character.increaseHark(hark);
     } catch (e) {
       await ctx.answerCbQuery(e.message);
-      x = true;
+      return;
     }
   }
   if (ctx.match.input === 'confirm') {
@@ -74,7 +73,7 @@ harkScene.action(/confirm|reset|back|increase(?=_)/, async (ctx) => {
     ctx.session.character.resetHarks();
     await ctx.answerCbQuery('Изменения успешно сброшены');
   }
-  if (x) return;
+
   await ctx.editMessageText(
     `Свободных очков ${ctx.session.character.free}`,
     Markup.inlineKeyboard([


### PR DESCRIPTION
кастылямба для блока ошибок, при попытке распределить 0 free, когда бот не может изменить сообщение о том что у вас 0, т.к у вас уже и так написано 0. Это ребутает ботака. 